### PR TITLE
Update CodeStyling.md: move const fields to top

### DIFF
--- a/Library/DevelopmentGuidelines/CodeStyling.md
+++ b/Library/DevelopmentGuidelines/CodeStyling.md
@@ -28,7 +28,10 @@ Have a standard ordering of members depending on their visibility and whether th
     //  Notice the order: static, private, protected, public, const, constructor, public, protected, private, static, inner classes
     public class MyClass
     {
-        // Static fields first
+        // Constants first
+        public const string MyConst = "const";
+        
+        // Static fields
         private static string _myStaticField = "field";
 
         // Private fields
@@ -38,9 +41,6 @@ Have a standard ordering of members depending on their visibility and whether th
 
         // Properties next
         public int MyProperty { get; set; }
-
-        // Constants just before the constructor
-        public const string MyConst = "const";
 
 
         // Then the constructor(s)


### PR DESCRIPTION
Same as in CoreLibrary, now.